### PR TITLE
Fix issue where cached cells were not reordered when using row object

### DIFF
--- a/media/js/ColReorderWithResize.js
+++ b/media/js/ColReorderWithResize.js
@@ -205,6 +205,16 @@
 
         /* Array array - internal data anodes cache */
         for (i = 0, iLen = oSettings.aoData.length; i < iLen; i++) {
+            if ($.isArray(oSettings.aoData[i]._aData))
+            {
+                // if data is simple array, swap elements by index
+                fnArraySwitch(oSettings.aoData[i]._aData, iFrom, iTo);
+            }
+            else if ($.isArray(oSettings.aoData[i].anCells))
+            {
+                // if data is row object, swap the internal cells representation instead (datatables uses this when setting column visible)
+                fnArraySwitch(oSettings.aoData[i].anCells, iFrom, iTo);
+            }
             fnArraySwitch(oSettings.aoData[i]._anHidden, iFrom, iTo);
         }
 


### PR DESCRIPTION
Fix issue where cached cells were not reordered when using row objects instead of simple array for data.

Issue was noticed when re-showing a column using `col.visible()` after it had been reordered and hidden.

Steps to reproduce:
1. Bind data to table using array of row objects w/ properties instead of ordinal-based data array. Example: `var aoRows = [{Id: 1, Name: 'Bob'}, {Id: 2, Name: 'Ray'}]`
2. Drag first column before second column
3. Hide first and second columns using `col.visible(false)` (DataTables API)
4. Show first and second columns using `col.visible(true)`
5. Note that column headers are OK, but column data is wrong (flipped)
